### PR TITLE
Fix database helpers imports and path handling

### DIFF
--- a/app/memory/long_term.py
+++ b/app/memory/long_term.py
@@ -1,8 +1,7 @@
-"""Persistent long-term memory backed by SQLite with vector search."""
+"""SQLite-backed long-term memory store."""
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import time
 from contextlib import contextmanager
@@ -27,17 +26,17 @@ CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at DESC);
 """
 
 
-def _ensure_database(path: str) -> None:
-    Path(os.path.dirname(path) or ".").mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(path) as conn:
+def _ensure_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
         conn.executescript(_DB_SCHEMA)
 
 
 @contextmanager
 def _connect() -> Iterable[sqlite3.Connection]:
-    db_path = config.memory.database_path
+    db_path = Path(config.memory.database_path)
     _ensure_database(db_path)
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(str(db_path))
     try:
         yield conn
     finally:
@@ -152,3 +151,4 @@ def has_seed(seed_id: str) -> bool:
             (pattern,),
         ).fetchone()
     return row is not None
+

--- a/app/persona_store.py
+++ b/app/persona_store.py
@@ -1,8 +1,7 @@
-"""Persistence helpers for persona records."""
+"""Persistence utilities for persona profiles."""
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import time
 from contextlib import contextmanager
@@ -11,7 +10,6 @@ from typing import Iterable, List, Optional
 
 from .config import config
 from .persona import Persona, PersonaProfile
-
 
 _TABLE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS personas (
@@ -29,17 +27,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_personas_name ON personas(name);
 """
 
 
-def _ensure_database(path: str) -> None:
-    Path(os.path.dirname(path) or ".").mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(path) as conn:
+def _ensure_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
         conn.executescript(_TABLE_SCHEMA)
 
 
 @contextmanager
 def _connect() -> Iterable[sqlite3.Connection]:
-    db_path = config.memory.database_path
+    db_path = Path(config.memory.database_path)
     _ensure_database(db_path)
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(str(db_path))
     try:
         yield conn
     finally:


### PR DESCRIPTION
## Summary
- ensure the long-term memory layer imports required modules and works with pathlib paths
- update persona persistence helpers to create database directories reliably

## Testing
- python -m compileall app streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68dccfeaa360833194b7e73ca9de8d33