### PR TITLE
Handle empty reflection outputs before persisting memories

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -115,14 +115,16 @@ class PersonaAgent:
         )
         draft = self.llm.complete(messages, max_tokens=800)
         reflection = self._generate_reflection(user_message, draft)
+        reflection_clean = reflection.strip()
         improved = self._apply_reflection(reflection, draft)
         assistant_turn = self.conversation.add("assistant", improved)
         assistant_turn.id = long_term.add_memory("assistant", improved, metadata={"type": "message"})
-        long_term.add_memory(
-            "assistant_reflection",
-            reflection,
-            metadata={"type": "reflection", "source": "self"},
-        )
+        if reflection_clean:
+            long_term.add_memory(
+                "assistant_reflection",
+                reflection_clean,
+                metadata={"type": "reflection", "source": "self"},
+            )
         plan = self._forecast_next_steps(user_message, improved)
         if plan.strip():
             long_term.add_memory(


### PR DESCRIPTION
## Summary
- avoid storing assistant reflection memories when the generated reflection is empty
- keep trimmed reflection content to ensure metadata storage remains consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd7f329288331975c55c29e7d69a5