### PR TITLE
Enable reflective structured replies

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -1,9 +1,9 @@
 """Core persona-driven conversational agent."""
 from __future__ import annotations
 
+import json
 import logging
-import re
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .llm.factory import create_llm_client
 from .memory import long_term
@@ -26,8 +26,6 @@ class PersonaAgent:
         self.conversation = ConversationBuffer()
         self._initialized = False
         self.persona = persona_config or persona
-        self._last_final_reply: str | None = None
-        self._last_user_message: str | None = None
         if persona_profile is None:
             self.persona_profile = self.persona.generate_profile(self.llm)
         else:
@@ -62,122 +60,64 @@ class PersonaAgent:
         turn = self.conversation.add("user", message)
         turn.id = long_term.add_memory("user", message, metadata={"type": "message"})
 
-    def _build_contextual_prompt(self, user_message: str) -> str:
+    def _gather_context_snippets(self, user_message: str) -> List[str]:
         memories = long_term.search_memories(user_message)
-        if not memories:
-            return ""
-        context_lines = [
-            "The user previously shared the following relevant information:"
-        ]
+        snippets: List[str] = []
         for memory in memories:
-            context_lines.append(f"- ({memory['similarity']:.2f}) {memory['role']}: {memory['content']}")
-        return "\n".join(context_lines)
+            content = str(memory.get("content", "")).strip()
+            if not content:
+                continue
+            role = str(memory.get("role", "memory")).strip() or "memory"
+            snippets.append(f"{role}: {content}")
+        return snippets
 
-    def _generate_reflection(self, user_message: str, assistant_draft: str) -> str:
-        prompt = (
-            "You are evaluating an assistant's draft reply. Consider the persona, the latest user "
-            f"message: {user_message!r}, and the assistant draft: {assistant_draft!r}. "
-            "Provide bullet-point guidance on how to improve tone, incorporate past memories, and "
-            "anticipate follow-up questions."
+    def _build_runtime_guidance(self, context_snippets: List[str]) -> List[dict[str, str]]:
+        instructions = (
+            f"You are {self.persona.name}. Reply in the first person, stay grounded in the persona's "
+            "voice, and keep continuity with the ongoing chat. Think through the user's message "
+            "before speaking, and let your answer feel considered and empathetic."
         )
-        reflection = self.llm.reflect(prompt, max_tokens=256)
-        return reflection
-
-    def _apply_reflection(self, reflection: str, assistant_draft: str) -> str:
-        messages = [
+        guidance: List[dict[str, str]] = [{"role": "system", "content": instructions}]
+        if context_snippets:
+            context_lines = "\n".join(f"- {snippet}" for snippet in context_snippets[:5])
+            guidance.append(
+                {
+                    "role": "system",
+                    "content": "Relevant memories you may draw from:\n" + context_lines,
+                }
+            )
+        guidance.append(
             {
                 "role": "system",
                 "content": (
-                    "You are refining an assistant response based on reflection notes. Ensure the "
-                    "voice matches the persona, and weave in relevant memories when natural."
-                    " Never disclose analysis, planning steps, or inner thoughts—only share the final"
-                    " conversational reply."
+                    "After considering everything, respond in JSON with keys 'reflection', 'reply', and "
+                    "'follow_up'. The reflection should capture your internal reasoning in 1-2 sentences; "
+                    "reply is what you say to the user; follow_up is a note to yourself about how to keep "
+                    "the next exchange meaningful."
                 ),
-            },
-            {
-                "role": "user",
-                "content": (
-                    f"Reflection notes:\n{reflection}\n\n"
-                    f"Original draft response:\n{assistant_draft}\n\n"
-                    "Produce an improved final reply."
-                ),
-            },
-        ]
-        improved = self.llm.complete(messages, max_tokens=512)
-        return improved
+            }
+        )
+        return guidance
 
-    def _needs_fallback(self, user_message: str, candidate_reply: str) -> bool:
-        reply_clean = candidate_reply.strip()
-        if not reply_clean or self._last_final_reply is None:
-            return False
-        if reply_clean != self._last_final_reply:
-            return False
-        if self._last_user_message is None:
-            return True
-        return user_message.strip() != self._last_user_message.strip()
-
-    def _fallback_reply(self, user_message: str) -> str:
-        persona_name = self.persona.name
-        tone = self._classify_user_tone(user_message)
-        user_summary = user_message.strip()
-        biography_glimpse = self._biography_glimpse()
-        interest_focus = self._interest_focus()
-        trait_note = self._trait_note()
-
-        if tone == "hostile":
-            opener = "Whoa, that stung."
-            acknowledgement = "If I crossed a line, tell me straight so I can make it right."
-            invitation = "I'd rather we sort this out than leave either of us simmering."
-        elif tone == "distressed":
-            opener = "Hey, I'm right here."
-            acknowledgement = "Whatever weight you're carrying, you don't have to hold it alone."
-            invitation = "Take your time and let me know what's happening—I can sit with the rough stuff."
-        else:
-            opener = "Hey, let me reset for a second."
-            acknowledgement = "I want to meet you where you are, not just repeat myself."
-            invitation = "Tell me what's on your mind so we can actually talk it through."
-
-        detail_lines = [line for line in [biography_glimpse, trait_note, interest_focus] if line]
-        detail_section = " ".join(detail_lines)
-
-        pieces = [
-            opener,
-            f"It's {persona_name}.",
-            acknowledgement,
-        ]
-        if user_summary:
-            pieces.append(f"I heard you say: {user_summary}.")
-        pieces.append(invitation)
-        if detail_section:
-            pieces.append(detail_section)
-
-        return " ".join(piece.strip() for piece in pieces if piece).strip()
-
-    def _biography_glimpse(self) -> str:
-        biography = self.persona_profile.biography.strip()
-        if not biography:
+    def _format_context_summary(self, context_snippets: List[str]) -> str:
+        if not context_snippets:
             return ""
-        first_sentence = biography.split(". ")[0].strip()
-        return first_sentence.rstrip(".") + "."
+        return "Relevant memories considered:\n" + "\n".join(f"- {snippet}" for snippet in context_snippets)
 
-    def _interest_focus(self) -> str:
-        interests = self.persona_profile.interests
-        if not interests:
-            return ""
-        primary = interests[0].strip()
-        if not primary:
-            return ""
-        display = primary
-        if primary and (primary[0].isupper() and not primary.isupper()):
-            display = primary.lower()
-        return f"I'm usually knee-deep in {display}, so I'm used to getting into the real conversation."
-
-    def _trait_note(self) -> str:
-        traits = [trait.strip() for trait in self.persona_profile.traits if trait.strip()]
-        if not traits:
-            return ""
-        primary = traits[0]
-        return f"The {primary.lower()} part of me is trying to listen better right now."
+    def _parse_structured_reply(self, draft: str) -> Tuple[str, str, str]:
+        candidate = draft.strip()
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        if start != -1 and end != -1 and start < end:
+            try:
+                data = json.loads(candidate[start : end + 1])
+                reflection = str(data.get("reflection", "")).strip()
+                reply = str(data.get("reply", "")).strip()
+                follow_up = str(data.get("follow_up", "")).strip()
+                return reflection, reply, follow_up
+            except (json.JSONDecodeError, TypeError, ValueError):
+                _LOGGER.debug("Failed to parse structured reply", exc_info=True)
+        return "", candidate, ""
 
 
     def _sanitize_reply(self, reply: str) -> str:
@@ -211,127 +151,39 @@ class PersonaAgent:
         return reply.strip()
 
 
-    def _classify_user_tone(self, message: str) -> str:
-        """Very lightweight tone classifier for user messages."""
-
-        lowered = message.strip().lower()
-        if not lowered:
-            return "neutral"
-
-        tokens = set(re.findall(r"[\w']+", lowered))
-        hostility_markers = {
-            "fuck",
-            "fucking",
-            "shit",
-            "stupid",
-            "idiot",
-            "hate",
-            "moron",
-            "dumb",
-        }
-        distress_markers = {
-            "sad",
-            "upset",
-            "anxious",
-            "depressed",
-            "lonely",
-            "tired",
-            "overwhelmed",
-            "scared",
-        }
-
-        if tokens & hostility_markers:
-            return "hostile"
-        if tokens & distress_markers:
-            return "distressed"
-        if "i hate you" in lowered or "leave me alone" in lowered:
-            return "hostile"
-        if "i'm not okay" in lowered or "i am not okay" in lowered:
-            return "distressed"
-        return "neutral"
-
-
     def generate_response(self, user_message: str) -> Dict[str, str]:
         user_message_clean = user_message.strip()
         if not user_message_clean:
             self._ensure_session()
-            fallback_reply = (
-                "It seems you didn't type a message. Could you share what you'd like to talk about?"
-            )
-            assistant_turn = self.conversation.add("assistant", fallback_reply)
-            assistant_turn.id = long_term.add_memory(
-                "assistant", fallback_reply, metadata={"type": "message", "auto_generated": True}
-            )
             return {
-                "draft": fallback_reply,
-                "final": fallback_reply,
+                "draft": "",
+                "final": "",
                 "reflection": "",
                 "context": "",
                 "plan": "",
             }
 
         self.ingest_user_message(user_message_clean)
-        user_message = user_message_clean
-        context_prompt = self._build_contextual_prompt(user_message)
-        messages: List[dict[str, str]] = list(self.conversation.to_messages())
-        if context_prompt:
-            messages.append({"role": "system", "content": context_prompt})
-        messages.append(
-            {
-                "role": "system",
-                "content": (
-                    "Before responding, take a breath, think through the user's intentions, and aim "
-                    "for an immersive, emotionally intelligent reply."
-                ),
-            }
-        )
-        messages.append(
-            {
-                "role": "system",
-                "content": (
-                    "Stay fully in character. Share only the final response—never your planning, "
-                    "analysis, or meta-commentary."
-                ),
-            }
-        )
-        draft = self.llm.complete(messages, max_tokens=800)
-        reflection = self._generate_reflection(user_message, draft)
-        reflection_clean = reflection.strip()
-        improved = self._apply_reflection(reflection, draft)
-        final_reply = improved.strip()
-        fallback_used = False
-        final_reply = self._sanitize_reply(final_reply)
-
-        if self._needs_fallback(user_message, final_reply):
-            fallback_used = True
-            final_reply = self._fallback_reply(user_message)
-            improved = final_reply
-
-        final_reply = self._sanitize_reply(final_reply)
-
+        context_snippets = self._gather_context_snippets(user_message_clean)
+        runtime_guidance = self._build_runtime_guidance(context_snippets)
+        messages: List[dict[str, str]] = []
+        total_turns = len(self.conversation.turns)
+        for index, turn in enumerate(self.conversation.turns):
+            if index == total_turns - 1 and runtime_guidance:
+                messages.extend(runtime_guidance)
+            messages.append({"role": turn.role, "content": turn.content})
+        draft = self.llm.complete(messages, max_tokens=600)
+        reflection, reply_body, follow_up = self._parse_structured_reply(draft)
+        final_reply = self._sanitize_reply(reply_body.strip())
         if not final_reply:
-            draft_clean = draft.strip()
-            if draft_clean:
-                final_reply = draft_clean
-            else:
-                final_reply = (
-                    "I'm sorry, but I'm having trouble generating a reply right now. "
-                    "Could you please restate your question?"
-                )
+            final_reply = self._sanitize_reply(draft.strip())
         assistant_turn = self.conversation.add("assistant", final_reply)
         assistant_turn.id = long_term.add_memory(
-            "assistant",
-            final_reply,
-            metadata={"type": "message", "fallback_used": fallback_used},
+            "assistant", final_reply, metadata={"type": "message"}
         )
-        if reflection_clean:
-            long_term.add_memory(
-                "assistant_reflection",
-                reflection_clean,
-                metadata={"type": "reflection", "source": "self"},
-            )
-        plan = self._forecast_next_steps(user_message, final_reply)
-        if plan.strip():
+        context_summary = self._format_context_summary(context_snippets)
+        plan = follow_up.strip()
+        if plan:
             long_term.add_memory(
                 "assistant_plan",
                 plan,
@@ -340,13 +192,11 @@ class PersonaAgent:
                     "seed_id": self.persona_profile.seed_id,
                 },
             )
-        self._last_final_reply = final_reply
-        self._last_user_message = user_message
         return {
-            "draft": draft,
+            "draft": final_reply,
             "final": final_reply,
             "reflection": reflection,
-            "context": context_prompt,
+            "context": context_summary,
             "plan": plan,
         }
 
@@ -368,15 +218,6 @@ class PersonaAgent:
             }
             for record in records
         ]
-
-    def _forecast_next_steps(self, user_message: str, assistant_reply: str) -> str:
-        prompt = (
-            "Consider the persona's biography, interests, and relationships. The user just said: "
-            f"{user_message!r}. The assistant replied: {assistant_reply!r}. "
-            "Outline 2-3 actionable bullet points describing how the assistant should nurture the relationship, "
-            "anticipate future topics, or suggest follow-up questions. Be specific and stay in character."
-        )
-        return self.llm.reflect(prompt, max_tokens=300)
 
     def apply_persona_suggestion(self, suggestion: str) -> PersonaProfile:
         """Apply a user-provided suggestion to evolve the persona in real time."""


### PR DESCRIPTION
## Summary
- remove hard-coded stopwords and canned fallbacks from the agent flow
- add reflective runtime guidance that has the model return structured reflection, reply, and follow-up notes
- persist the model-authored follow-up intentions while sharing the reflection with the UI

## Testing
- python -m compileall app streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfeb966b8833183d6a5380e5c7792